### PR TITLE
[1.12.2] Walls don't connect to glass fix

### DIFF
--- a/src/main/java/thedarkcolour/futuremc/block/villagepillage/BlockWall.kt
+++ b/src/main/java/thedarkcolour/futuremc/block/villagepillage/BlockWall.kt
@@ -9,6 +9,7 @@ import net.minecraft.block.properties.PropertyBool
 import net.minecraft.block.state.BlockFaceShape
 import net.minecraft.block.state.BlockStateContainer
 import net.minecraft.block.state.IBlockState
+import net.minecraft.block.BlockGlass
 import net.minecraft.entity.Entity
 import net.minecraft.init.Blocks
 import net.minecraft.util.EnumFacing
@@ -61,7 +62,7 @@ class BlockWall(properties: Properties) : FBlock(properties), IFluidloggable {
         val state = worldIn.getBlockState(pos)
         val block = state.block
         val shape = state.getBlockFaceShape(worldIn, pos, facing)
-        val flag = shape == BlockFaceShape.MIDDLE_POLE_THICK || shape == BlockFaceShape.MIDDLE_POLE && block is BlockFenceGate
+        val flag = shape == BlockFaceShape.MIDDLE_POLE_THICK || shape == BlockFaceShape.MIDDLE_POLE && block is BlockFenceGate || block is BlockGlass
         return !isExceptBlockForAttachWithPiston(block) && shape == BlockFaceShape.SOLID || flag
     }
 


### PR DESCRIPTION
This is the easiest way I could consider to fix this. Gradle build is not working on my machine natively, weird issue with dependencies so I wasn't able to test. If there is a better way to do this let me know. This is intended behaviour in vanilla.