### PR TITLE
Fix jungle bamboo generation on worlds with multiple biomes

### DIFF
--- a/src/main/java/thedarkcolour/futuremc/world/gen/feature/BambooWorldGen.kt
+++ b/src/main/java/thedarkcolour/futuremc/world/gen/feature/BambooWorldGen.kt
@@ -43,8 +43,8 @@ object BambooWorldGen : FWorldGen {
         chunkGenerator: IChunkGenerator,
         chunkProvider: IChunkProvider
     ) {
-        val x = chunkX + rand.nextInt(16) + 8
-        val z = chunkZ + rand.nextInt(16) + 8
+        val x = (chunkX * 16) + 8
+        val z = (chunkZ * 16) + 8
         val position = BlockPos(x, 0, z)
         val biome = worldIn.getBiomeForCoordsBody(position)
         val chunkPos = worldIn.getChunk(chunkX, chunkZ).pos

--- a/src/main/java/thedarkcolour/futuremc/world/gen/feature/BambooWorldGen.kt
+++ b/src/main/java/thedarkcolour/futuremc/world/gen/feature/BambooWorldGen.kt
@@ -43,8 +43,8 @@ object BambooWorldGen : FWorldGen {
         chunkGenerator: IChunkGenerator,
         chunkProvider: IChunkProvider
     ) {
-        val x = (chunkX * 16) + 8
-        val z = (chunkZ * 16) + 8
+        val x = (chunkX shl 4) + 8
+        val z = (chunkZ shl 4) + 8
         val position = BlockPos(x, 0, z)
         val biome = worldIn.getBiomeForCoordsBody(position)
         val chunkPos = worldIn.getChunk(chunkX, chunkZ).pos


### PR DESCRIPTION
This fixes the cause of bamboo generation being inconsistent across worldtypes.

In particular, I found that on worldtypes other than single, customized, jungle-only, bamboo would not generate.

---

Here's the problem code:

```
46    val x = chunkX + rand.nextInt(16) + 8
47    val z = chunkZ + rand.nextInt(16) + 8
48    val position = BlockPos(x, 0, z)
49    val biome = worldIn.getBiomeForCoordsBody(position)
50    val chunkPos = worldIn.getChunk(chunkX, chunkZ).pos
51    if (isBiomeValid(biome) && worldIn.worldType != WorldType.FLAT) {
52        FWorldGen.placeAround(worldIn, rand, chunkPos, 0..22) { world2, random, pos ->
53            generate(world2, random, pos)
54        }
```

Line 52 actually starts the bamboo placement, but this is on condition that "isBiomeValid(biome)" passes. The problem is that the biome is fetched by adding the chunk co-ordinates, to a random integer for some reason, and then using *that* as a BlockPos when X and Z represent chunks, not blocks.

For example, if you are in chunk 200, 0, 200, this code will do BlockPos(200, 0, 200) and then get the biome of what's at that co-ordinate, when the intended behaviour should be to get the biome of what's at the co-ordinates 3200, 0, 3200

Interestingly, this is why the current bamboo generation only works on customized single-biome jungle worlds. The generator is sampling a block 16x closer to the origin for the biome check, and then conveniently finding the correct biome type anyway.

---

My proposed fix is this:

```
46    val x = (chunkX * 16) + 8
47    val z = (chunkX * 16) + 8
```

Doing this multiplication means that the value of position will equal a center block of the chunk being tested by line 49, and fixes the issue. I've also removed the random integer because... ? It doesn't seem to add anything.

I've included a screenshot of the variables from a debug run that found the issue. Ignore the tries being set to 2200 on line 52, that was just to make sure a *lot* of bamboo shows up during testing. 😅

![bamboo faulty generation](https://github.com/thedarkcolour/Future-MC/assets/44021545/2cb65efc-7392-48dc-9a4b-e1c9750e3fa2)

And once again, thank you for your hard work on this mod!