### PR TITLE
Fix scaffold teleportation behaviour bug

### DIFF
--- a/src/main/java/thedarkcolour/futuremc/item/ScaffoldingItem.kt
+++ b/src/main/java/thedarkcolour/futuremc/item/ScaffoldingItem.kt
@@ -43,12 +43,12 @@ class ScaffoldingItem : ModeledItemBlock(FBlocks.SCAFFOLDING) {
                 var found = false
 
                 while (i < 7) {
-                    if (!worldIn.isRemote && !worldIn.worldBorder.contains(cursor)) {
-                        if (player is EntityPlayerMP && cursor.y >= 255) {
-                            // todo send world border message
-                        }
-                        break
-                    }
+//                    if (!worldIn.isRemote && !worldIn.worldBorder.contains(cursor)) {
+//                        if (player is EntityPlayerMP && cursor.y >= 255) {
+//                            // todo send world border message
+//                        }
+//                        break
+//                    }
 
                     val state = worldIn.getBlockState(cursor)
                     if (state.block != this.block) {

--- a/src/main/resources/META-INF/futuremc_at.cfg
+++ b/src/main/resources/META-INF/futuremc_at.cfg
@@ -19,6 +19,7 @@ public net.minecraft.entity.ai.EntityAIPanic func_188497_a(Lnet/minecraft/world/
 public net.minecraft.entity.ai.EntityAIWatchClosest field_75331_e # chance
 public net.minecraft.inventory.ContainerMerchant field_75177_g # world
 public net.minecraft.entity.EntityLivingBase field_184627_bm # activeItemStack
+public net.minecraft.world.World field_175728_M # worldBorder
 
 
 # We are water


### PR DESCRIPTION
This fixes the apparent scaffold teleportation seen when players try to use scaffolding. For posterity, I've included a video of the behaviour.

https://www.youtube.com/watch?v=99UyO8SmOnQ

---

The problem is in class `ScaffoldingItem` on line 46, for the world border check.

```
45    while (i < 7) {
46        if (!worldIn.isRemote && !worldIn.worldBorder.contains(cursor)) {
47            if (player is EntityPlayerMP && cursor.y >= 255) {
48                // todo send world border message
49            }
50            break
51        }
51    ...
```

I was initially able to narrow the change down to when FutureMC switched from FancyGradle to RetroFuturaGradle. Something about that change caused the field for `worldBorder` to be lost. I couldn't tell you what specifically changed in the `build.gradle` to cause that.

What I do know is, this code is not called on the logical client, but *is* called on the logical server. The result was that, when scaffolding was directly placed as a block, this code is skipped. But, when scaffolding was placed by right clicking a scaffolding while wielding a scaffold item, this code is called, and then the result was only being drawn on the client side.

Proof for this is to take the current build, place a few Scaffolding blocks in a tower, and then relog. Only the base block will have been saved.

When the logical server runs this code, it breaks on line 46 because it passes the `!worldIn.isRemote` check, but freezes on the second check. This was confirmed by removing the side check, keeping (`if (!worldIn.worldBorder.contains(cursor))` only) , and sure enough, the crash happens on client side too.

---

I've provided two fixes for this, I recommend keeping both.

Firstly, I've added the relevant access transformer to the config for `worldBorder`. This solves the bug on it's own.

```
public net.minecraft.world.World field_175728_M # worldBorder
```

But secondly, I've commented out the code. If you don't wish to add another access transformer, and want the bug to be fixed *for now*, the code has to stay commented out. This code only only optimizes at edge cases where players are using scaffolding near the world border ceiling. Running this check every time a scaffold is built, on every loop, just to optimize for the small chance that a player is scaffolding at world ceiling, *just* to break out early on a single scaffold item click, is more wasteful than doing nothing.

I've tested both of these solutions in isolation, and as a combo, and all solutions work in both regular play, and at the world ceiling.