### PR TITLE
Run set gametype on main

### DIFF
--- a/src/main/java/thedarkcolour/futuremc/network/GameModeSwitchPacket.kt
+++ b/src/main/java/thedarkcolour/futuremc/network/GameModeSwitchPacket.kt
@@ -31,7 +31,9 @@ class GameModeSwitchPacket() : IMessage {
             val playerIn = ctx.serverHandler.player
 
             if (message.gameType != GameType.NOT_SET && playerIn.canUseCommand(2, "gamemode")) {
-                playerIn.setGameType(message.gameType)
+                playerIn.serverWorld.addScheduledTask {
+                    playerIn.setGameType(message.gameType)
+                }
                 val text = TextComponentTranslation("gameMode." + message.gameType.getName(), *arrayOfNulls<Any>(0))
 
                 if (playerIn.world.gameRules.getBoolean("sendCommandFeedback")) {


### PR DESCRIPTION
This pull request makes setting gametype tasks run on server thread.

Setting gametype asynchronously is unsafe, and triggers AsyncCatcher warnings